### PR TITLE
Refactor OllamaService methods

### DIFF
--- a/internal/ai/ollama.go
+++ b/internal/ai/ollama.go
@@ -240,8 +240,8 @@ func (s *OllamaService) GenerateInsight(ctx context.Context, req *InsightRequest
 		timeoutCtx, cancel := context.WithTimeout(ctx, 60*time.Second)
 		defer cancel()
 
-		// Use langchaingo Call method
-		response, err := s.llm.Call(timeoutCtx, prompt)
+		// Use langchaingo GenerateFromSinglePrompt method
+		response, err := llms.GenerateFromSinglePrompt(timeoutCtx, s.llm, prompt)
 		if err == nil {
 			s.logger.LogInfo(ctx, "Insight generation successful",
 				logging.OperationField, "generate_insight",
@@ -458,8 +458,8 @@ func (s *OllamaService) GenerateWeeklyReport(ctx context.Context, userID string,
 		timeoutCtx, cancel := context.WithTimeout(ctx, 90*time.Second)
 		defer cancel()
 
-		// Use langchaingo Call method
-		response, err := s.llm.Call(timeoutCtx, prompt)
+		// Use langchaingo GenerateFromSinglePrompt method
+		response, err := llms.GenerateFromSinglePrompt(timeoutCtx, s.llm, prompt)
 		if err == nil {
 			s.logger.LogInfo(ctx, "Weekly report generation successful",
 				logging.OperationField, "generate_weekly_report",
@@ -528,7 +528,7 @@ func (s *OllamaService) HealthCheck(ctx context.Context) error {
 	testPrompt := "Respond with 'OK' to confirm you are working."
 
 	start := time.Now()
-	response, err := s.llm.Call(healthCtx, testPrompt)
+	response, err := llms.GenerateFromSinglePrompt(healthCtx, s.llm, testPrompt)
 	duration := time.Since(start)
 
 	if err != nil {


### PR DESCRIPTION
This pull request refactors the `OllamaService` to replace the use of the `langchaingo` library's `Call` method with the `GenerateFromSinglePrompt` method for improved consistency and maintainability across multiple functions.

### Refactoring to use `GenerateFromSinglePrompt`:

* Updated `func (s *OllamaService) GenerateInsight` to use `llms.GenerateFromSinglePrompt` instead of `s.llm.Call` for generating insights. (`internal/ai/ollama.go`, [internal/ai/ollama.goL243-R244](diffhunk://#diff-db8ca675e4ffe2c29b39f2563eb0f87b965c915407267129b12e0ed757ff91ceL243-R244))
* Updated `func (s *OllamaService) GenerateWeeklyReport` to use `llms.GenerateFromSinglePrompt` instead of `s.llm.Call` for generating weekly reports. (`internal/ai/ollama.go`, [internal/ai/ollama.goL461-R462](diffhunk://#diff-db8ca675e4ffe2c29b39f2563eb0f87b965c915407267129b12e0ed757ff91ceL461-R462))
* Updated `func (s *OllamaService) HealthCheck` to use `llms.GenerateFromSinglePrompt` instead of `s.llm.Call` for performing health checks. (`internal/ai/ollama.go`, [internal/ai/ollama.goL531-R531](diffhunk://#diff-db8ca675e4ffe2c29b39f2563eb0f87b965c915407267129b12e0ed757ff91ceL531-R531))